### PR TITLE
scrollBar fix

### DIFF
--- a/addon/components/combo-box.js
+++ b/addon/components/combo-box.js
@@ -56,9 +56,17 @@ function scrollTop($element, step) {
       curOffset -= (interval * step);
       $element[0].scrollTo(0, curOffset);
       count++;
-      if (count > 150 || curOffset < 0) clearInterval(intervalRef);
+      if (count > 150 || curOffset < 0) {
+        $element.off("scroll.stopAnimation");
+        clearInterval(intervalRef)
+      }
     }
   })(step, start--), 50);
+
+  $element.on("scroll.stopAnimation", function() {
+    $element.off("scroll.stopAnimation");
+    clearInterval(intervalRef);
+  })
 }
 
 function getObjectFromArray(array, index) {


### PR DESCRIPTION
Bug: bugging scroll first few seconds caused by scrollTop function  (jquery 'polyfill)' - in setTinterval()

FIx suggestion: scrollBar fix by using scroll events