### PR TITLE
set inputDisplayValue with noValueLabel (readOnlyMode)

### DIFF
--- a/addon/components/combo-box.js
+++ b/addon/components/combo-box.js
@@ -256,6 +256,17 @@ export default Component.extend({
         ) {
           return '';
         }
+
+        //set this.noValueLabel as inputDisplayValue, if its readonly mode and with empty list
+        let noValueLabel = this.noValueLabel;
+        if (
+          isEmpty(this.valueList) &&
+          isPresent(noValueLabel) &&
+          noValueLabel.length > 0 &&
+          this.labelOnly === true
+        ) {
+          return this.noValueLabel;
+        }
       }
       return this.inputValue;
     },


### PR DESCRIPTION
combobox was setting inputDisplayValue with noValueLabel only in init. WHen noValueLabel changed, inputDisplayValue did not change, so this PR fixes this bug